### PR TITLE
add arguments for setting system prompts

### DIFF
--- a/scripts/inference/gradio_demo.py
+++ b/scripts/inference/gradio_demo.py
@@ -12,6 +12,17 @@ from threading import Thread
 import traceback
 import gc
 
+DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant. 你是一个乐于助人的助手。"""
+
+TEMPLATE_WITH_SYSTEM_PROMPT = (
+    "[INST] <<SYS>>\n"
+    "{system_prompt}\n"
+    "<</SYS>>\n\n"
+    "{instruction} [/INST]"
+)
+
+TEMPLATE_WITHOUT_SYSTEM_PROMPT = "[INST] {instruction} [/INST]"
+
 # Parse command-line arguments
 parser = argparse.ArgumentParser()
 parser.add_argument(
@@ -52,6 +63,12 @@ parser.add_argument(
     type=str,
     default="1.0",
     help="The scaling factor of NTK method, can be a float or 'auto'. ")
+parser.add_argument(
+    '--system_prompt',
+    type=str,
+    default=DEFAULT_SYSTEM_PROMPT,
+    help="The system prompt of the prompt template."
+)
 args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
@@ -132,20 +149,10 @@ def reset_state():
     return []
 
 
-DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant. 你是一个乐于助人的助手。"""
-
-TEMPLATE_WITH_SYSTEM_PROMPT = (
-    "[INST] <<SYS>>\n"
-    "{system_prompt}\n"
-    "<</SYS>>\n\n"
-    "{instruction} [/INST]"
-)
-
-TEMPLATE_WITHOUT_SYSTEM_PROMPT = "[INST] {instruction} [/INST]"
-
 def generate_prompt(instruction, response="", with_system_prompt=True):
     if with_system_prompt is True:
-        prompt = TEMPLATE_WITH_SYSTEM_PROMPT.format_map({'instruction': instruction,'system_prompt': DEFAULT_SYSTEM_PROMPT})
+        system_prompt = args.system_prompt or DEFAULT_SYSTEM_PROMPT
+        prompt = TEMPLATE_WITH_SYSTEM_PROMPT.format_map({'instruction': instruction,'system_prompt': system_prompt})
     else:
         prompt = TEMPLATE_WITHOUT_SYSTEM_PROMPT.format_map({'instruction': instruction})
     if len(response)>0:

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -1,5 +1,15 @@
 import argparse
 import json, os
+
+DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant. 你是一个乐于助人的助手。"""
+
+TEMPLATE = (
+    "[INST] <<SYS>>\n"
+    "{system_prompt}\n"
+    "<</SYS>>\n\n"
+    "{instruction} [/INST]"
+)
+
 parser = argparse.ArgumentParser()
 parser.add_argument('--base_model', default=None, type=str, required=True)
 parser.add_argument('--lora_model', default=None, type=str,help="If None, perform inference on the base model")
@@ -12,7 +22,7 @@ parser.add_argument('--gpus', default="0", type=str)
 parser.add_argument('--only_cpu',action='store_true',help='only use CPU for inference')
 parser.add_argument('--alpha',type=str,default="1.0", help="The scaling factor of NTK method, can be a float or 'auto'. ")
 parser.add_argument('--load_in_8bit',action='store_true', help="Load the LLM in the 8bit mode")
-
+parser.add_argument('--system_prompt',type=str,default=DEFAULT_SYSTEM_PROMPT, help="The system prompt of the prompt template.")
 args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
@@ -39,19 +49,11 @@ generation_config = GenerationConfig(
     max_new_tokens=400
 )
 
-DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant. 你是一个乐于助人的助手。"""
-
-TEMPLATE = (
-    "[INST] <<SYS>>\n"
-    "{system_prompt}\n"
-    "<</SYS>>\n\n"
-    "{instruction} [/INST]"
-)
-
 sample_data = ["为什么要减少污染，保护环境？"]
 
 def generate_prompt(instruction):
-    return TEMPLATE.format_map({'instruction': instruction,'system_prompt': DEFAULT_SYSTEM_PROMPT})
+    system_prompt = args.system_prompt or DEFAULT_SYSTEM_PROMPT
+    return TEMPLATE.format_map({'instruction': instruction,'system_prompt': system_prompt})
 
 if __name__ == '__main__':
     load_type = torch.float16


### PR DESCRIPTION
### Description

This PR adds arguments for setting system prompts in the inference scripts (`inference_hf.py` and `gradio_demo.py`) to accommodate for the convenient switching  between different system prompts, such as the ones listed in https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/tree/main/prompts 

### Related Issue

None.