### PR TITLE
add support for 4bit inference

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ torch==2.0.1
 git+https://github.com/huggingface/peft.git@13e53fc
 transformers==4.31.0
 sentencepiece==0.1.97
-bitsandbytes==0.39.1
+bitsandbytes==0.41.0

--- a/scripts/inference/gradio_demo.py
+++ b/scripts/inference/gradio_demo.py
@@ -58,11 +58,11 @@ parser.add_argument(
 parser.add_argument(
     '--load_in_8bit',
     action='store_true',
-    help='Use 8 bit quantified model')
+    help='Use 8 bit quantized model')
 parser.add_argument(
     '--load_in_4bit',
     action='store_true',
-    help='Use 4 bit quantified model')
+    help='Use 4 bit quantized model')
 parser.add_argument(
     '--only_cpu',
     action='store_true',
@@ -96,7 +96,7 @@ args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("Quantization is unavailable in CPU.")
+        raise ValueError("Quantization is unavailable on CPU.")
 if args.load_in_8bit and args.load_in_4bit:
     raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 import sys

--- a/scripts/inference/gradio_demo.py
+++ b/scripts/inference/gradio_demo.py
@@ -96,9 +96,9 @@ args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("The installed version of bitsandbytes was compiled without GPU support. Quantization is unavailable")
+        raise ValueError("Quantization is unavailable in CPU.")
 if args.load_in_8bit and args.load_in_4bit:
-    raise ValueError("Only one quantization method can be chosen for inference.Please check your arguments")
+    raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 import sys
 parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 sys.path.append(parent_dir)

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -34,11 +34,11 @@ if args.use_vllm:
     if args.only_cpu:
         raise ValueError("vLLM requires GPUs with compute capability not less than 7.0. If you want to run only on CPU, please unuse --use_vllm.")
 if args.load_in_8bit and args.load_in_4bit:
-    raise ValueError("Only one quantization method can be chosen for inference.Please check your arguments")
+    raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("The installed version of bitsandbytes was compiled without GPU support. Quantization is unavailable")
+        raise ValueError("Quantization is unavailable in CPU.")
 os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 import torch
 from transformers import LlamaForCausalLM, LlamaTokenizer

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -21,19 +21,24 @@ parser.add_argument('--predictions_file', default='./predictions.json', type=str
 parser.add_argument('--gpus', default="0", type=str)
 parser.add_argument('--only_cpu',action='store_true',help='only use CPU for inference')
 parser.add_argument('--alpha',type=str,default="1.0", help="The scaling factor of NTK method, can be a float or 'auto'. ")
-parser.add_argument('--load_in_kbit', default=16, help="Load the LLM in the kbit mode", type=int, choices=[4, 8, 16])
+parser.add_argument('--load_in_8bit',action='store_true', help="Load the LLM in the 8bit mode")
+parser.add_argument('--load_in_4bit',action='store_true', help="Load the LLM in the 4bit mode")
 parser.add_argument("--use_vllm", action='store_true', help="Use vLLM as back-end LLM service.")
 parser.add_argument('--system_prompt',type=str,default=DEFAULT_SYSTEM_PROMPT, help="The system prompt of the prompt template.")
 args = parser.parse_args()
 if args.use_vllm:
     if args.lora_model is not None:
         raise ValueError("vLLM currently does not support LoRA, please merge the LoRA weights to the base model.")
-    if args.load_in_8bit:
+    if args.load_in_8bit or args.load_in_4bit:
         raise ValueError("vLLM currently does not support quantization, please use fp16 (default) or unuse --use_vllm.")
     if args.only_cpu:
         raise ValueError("vLLM requires GPUs with compute capability not less than 7.0. If you want to run only on CPU, please unuse --use_vllm.")
+if args.load_in_8bit and args.load_in_4bit:
+    raise ValueError("Only one quantization method can be chosen for inference.Please check your arguments")
 if args.only_cpu is True:
     args.gpus = ""
+    if args.load_in_8bit or args.load_in_4bit:
+        raise ValueError("The installed version of bitsandbytes was compiled without GPU support. Quantization is unavailable")
 os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 import torch
 from transformers import LlamaForCausalLM, LlamaTokenizer
@@ -101,8 +106,8 @@ if __name__ == '__main__':
             low_cpu_mem_usage=True,
             device_map='auto',
             quantization_config=BitsAndBytesConfig(
-                load_in_4bit=args.load_in_kbit == 4,
-                load_in_8bit=args.load_in_kbit == 8,
+                load_in_4bit=args.load_in_4bit,
+                load_in_8bit=args.load_in_8bit,
                 bnb_4bit_compute_dtype=load_type
             )
             )

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -38,7 +38,7 @@ if args.load_in_8bit and args.load_in_4bit:
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("Quantization is unavailable in CPU.")
+        raise ValueError("Quantization is unavailable on CPU.")
 os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 import torch
 from transformers import LlamaForCausalLM, LlamaTokenizer

--- a/scripts/openai_server_demo/openai_api_server.py
+++ b/scripts/openai_server_demo/openai_api_server.py
@@ -16,7 +16,7 @@ args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("Quantization is unavailable in CPU.")
+        raise ValueError("Quantization is unavailable on CPU.")
 if args.load_in_8bit and args.load_in_4bit:
     raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus

--- a/scripts/openai_server_demo/openai_api_server.py
+++ b/scripts/openai_server_demo/openai_api_server.py
@@ -16,9 +16,9 @@ args = parser.parse_args()
 if args.only_cpu is True:
     args.gpus = ""
     if args.load_in_8bit or args.load_in_4bit:
-        raise ValueError("The installed version of bitsandbytes was compiled without GPU support. Quantization is unavailable")
+        raise ValueError("Quantization is unavailable in CPU.")
 if args.load_in_8bit and args.load_in_4bit:
-    raise ValueError("Only one quantization method can be chosen for inference.Please check your arguments")
+    raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 os.environ["CUDA_VISIBLE_DEVICES"] = args.gpus
 
 import torch


### PR DESCRIPTION
### Description

This PR adds support for 4-bit inference, which can effectively reduce the VRAM. The VRAM after loading the model is as follows (in Tesla P40) :

| load_in_4bit | load_in_8bit | fp16 |
| :-: | :-: | :-: | 
| 4999M | 7989M | 13759M |

**Usage**
Just add the `--load_in_4bit` to the launching command. For example:
```
python scripts/inference/inference_hf.py \
    --base_model path_to_merged_llama2_or_alpaca2_hf_dir \
    --with_prompt \
    --load_in_4bit \
    --interactive
```

### Related Issue
None.

