### PR TITLE
Add server examples for llama.cpp

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,9 +32,9 @@ Inference Script for C-Eval, Wiki: https://github.com/ymcui/Chinese-LLaMA-Alpaca
 
 ### llama-cpp/
 
-llama.cpp启动脚本，Wiki：[https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh](https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh)
+llama.cpp启动脚本、server脚本，Wiki：[https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh](https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh)
 
-launch script for llama.cpp, Wiki: https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_en
+launch script and server script for llama.cpp, Wiki: https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_en
 
 
 ### attn_ang_long_ctx_patches.py

--- a/scripts/llama-cpp/README.md
+++ b/scripts/llama-cpp/README.md
@@ -1,0 +1,17 @@
+## llama.cpp相关示例脚本
+
+具体使用方法参考：https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh
+
+Detailed usage: https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_en
+
+### chat.sh
+
+用于与Alpaca-2系列模型进行对话交流。
+
+Chat with Alpaca-2 models.
+
+### server_curl_example.sh
+
+架设server后使用curl调用示例。
+
+An example to use curl for API calls after setting up server.

--- a/scripts/llama-cpp/server_curl_example.sh
+++ b/scripts/llama-cpp/server_curl_example.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# NOTE: start the server first before running this script.
+# usage: ./server_curl_example.sh your-instruction
+
+SYSTEM_PROMPT='You are a helpful assistant. 你是一个乐于助人的助手。'
+# SYSTEM_PROMPT='You are a helpful assistant. 你是一个乐于助人的助手。请你提供专业、有逻辑、内容真实、有价值的详细回复。' # Try this one, if you prefer longer response.
+INSTRUCTION=$1
+ALL_PROMPT="[INST] <<SYS>>\n$SYSTEM_PROMPT\n<</SYS>>\n\n$INSTRUCTION [/INST]"
+CURL_DATA="{\"prompt\": \"$ALL_PROMPT\",\"n_predict\": 128}"
+
+curl --request POST \
+    --url http://localhost:8080/completion \
+    --header "Content-Type: application/json" \
+    --data "$CURL_DATA"


### PR DESCRIPTION
### Description

Add server examples for llama.cpp. The user can follow our instructions to set up server and use `curl` or other ways to perform API calls.

ZH wiki: https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_zh#延伸用途架设server
EN wiki: https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/wiki/llamacpp_en#extended-application-setting-up-a-server

### Related Issue
None.

### Explanation of Changes
copilot:walkthrough
