### PR TITLE
Add --verbose argument to the C-Eval script

### DIFF
--- a/scripts/ceval/eval.py
+++ b/scripts/ceval/eval.py
@@ -89,6 +89,7 @@ if __name__ == "__main__":
     parser.add_argument("--do_save_csv", choices=["False","True"], default="False")
     parser.add_argument("--output_dir", type=str)
     parser.add_argument("--do_test", choices=["False","True"], default="False")
+    parser.add_argument("--verbose", action="store_true", help="Print detailed information of each example.")
 
     args = parser.parse_args()
 
@@ -109,7 +110,8 @@ if __name__ == "__main__":
         k=args.ntrain,
         model_path=args.model_path,
         device=device,
-        temperature = args.temperature
+        temperature = args.temperature,
+        verbose = args.verbose
     )
     for i in range(args.n_times):
         main(args,evaluator=evaluator,take=i)

--- a/scripts/ceval/llama_evaluator.py
+++ b/scripts/ceval/llama_evaluator.py
@@ -14,11 +14,12 @@ DEFAULT_SYSTEM_PROMPT = """You are a helpful assistant. 你是一个乐于助人
 
 
 class Llama_Evaluator(Evaluator):
-    def __init__(self, choices, k, model_path, device, temperature=0.2):
+    def __init__(self, choices, k, model_path, device, temperature=0.2, verbose=False):
         super(Llama_Evaluator, self).__init__(choices, model_path, k)
         load_type = torch.float16
         self.model_path = model_path
         self.device = device
+        self.verbose = verbose
         self.tokenizer = LlamaTokenizer.from_pretrained(model_path, legacy=True)
         self.model = LlamaForCausalLM.from_pretrained(
             model_path,
@@ -113,15 +114,15 @@ class Llama_Evaluator(Evaluator):
                 correct = 1
             else:
                 correct = 0
-            print(f"\n=======begin {str(row_index)}=======")
-            print("question: ", question)
-            print("response: ", response)
-            print("ans: ", ans)
-            print("ground truth: ", answers[row_index], "\n")
+            if self.verbose is True:
+                print(f"\n======={str(row_index)}=======")
+                print(f"question: {question}\n")
+                print(f"response: {response}\n")
+                print(f"extracted answer: {ans}")
+                print(f"ground truth: {answers[row_index]} \n")
             if save_result_dir:
                 result.append(response)
                 score.append(correct)
-            print(f"=======end {str(row_index)}=======")
 
             all_answers[str(row_index)] = ans
 


### PR DESCRIPTION
### Description

Add `--verbose` argument to the C-Eval script.

When `--verbose` is provided, the script will show detailed information of each example (including input, response, extracted answers from the response, and the ground truth label). 

### Related Issue

None