### PR TITLE
Add CFG sampling

### DIFF
--- a/scripts/inference/gradio_demo.py
+++ b/scripts/inference/gradio_demo.py
@@ -96,7 +96,7 @@ except ImportError:
     ENABLE_CFG_SAMPLING=False
     print("Install the latest transformers (commit equal or later than d533465) to enable CFG sampling.")
 if args.use_vllm is True:
-    ("CFG sampling is disabled when using vLLM.")
+    print("CFG sampling is disabled when using vLLM.")
     ENABLE_CFG_SAMPLING=False
 
 if args.only_cpu is True:

--- a/scripts/inference/gradio_demo.py
+++ b/scripts/inference/gradio_demo.py
@@ -89,15 +89,15 @@ parser.add_argument(
     help="Port of vLLM service.")
 args = parser.parse_args()
 
-ENABLE_CFG_SAMPLING=True
+ENABLE_CFG_SAMPLING = True
 try:
     from transformers.generation import UnbatchedClassifierFreeGuidanceLogitsProcessor
 except ImportError:
-    ENABLE_CFG_SAMPLING=False
+    ENABLE_CFG_SAMPLING = False
     print("Install the latest transformers (commit equal or later than d533465) to enable CFG sampling.")
 if args.use_vllm is True:
     print("CFG sampling is disabled when using vLLM.")
-    ENABLE_CFG_SAMPLING=False
+    ENABLE_CFG_SAMPLING = False
 
 if args.only_cpu is True:
     args.gpus = ""
@@ -355,13 +355,13 @@ def predict(
     guidance_scale=1.0,
     presence_penalty=0.0,
 ):
-    if len(system_prompt)==0:
+    if len(system_prompt) == 0:
         system_prompt = DEFAULT_SYSTEM_PROMPT
     while True:
         print("len(history):", len(history))
         print("history: ", history)
         history[-1][1] = ""
-        if len(history)==1:
+        if len(history) == 1:
             input = history[0][0]
             prompt = generate_prompt(input,response="", with_system_prompt=True, system_prompt=system_prompt)
         else:
@@ -407,7 +407,7 @@ def predict(
 
     else:
         negative_text = None
-        if len(negative_prompt)!=0:
+        if len(negative_prompt) != 0:
             negative_text = re.sub(r"<<SYS>>\n(.*)\n<</SYS>>", f"<<SYS>>\n{negative_prompt}\n<</SYS>>", prompt)
         inputs = tokenizer(prompt, return_tensors="pt")
         input_ids = inputs["input_ids"].to(device)

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -87,7 +87,7 @@ else:
 
 sample_data = ["为什么要减少污染，保护环境？"]
 
-def generate_prompt(instruction, system_prompt = DEFAULT_SYSTEM_PROMPT):
+def generate_prompt(instruction, system_prompt=DEFAULT_SYSTEM_PROMPT):
     return TEMPLATE.format_map({'instruction': instruction,'system_prompt': system_prompt})
 
 if __name__ == '__main__':
@@ -241,7 +241,7 @@ if __name__ == '__main__':
                         input_text = example
                         negative_text = args.negative_prompt
                     inputs = tokenizer(input_text,return_tensors="pt")  #add_special_tokens=False ?
-                    if args.guidance_scale ==1:
+                    if args.guidance_scale == 1:
                         generation_output = model.generate(
                             input_ids = inputs["input_ids"].to(device),
                             attention_mask = inputs['attention_mask'].to(device),

--- a/scripts/inference/inference_hf.py
+++ b/scripts/inference/inference_hf.py
@@ -25,7 +25,16 @@ parser.add_argument('--load_in_8bit', action='store_true', help="Load the LLM in
 parser.add_argument('--load_in_4bit', action='store_true', help="Load the LLM in the 4bit mode")
 parser.add_argument("--use_vllm", action='store_true', help="Use vLLM as back-end LLM service.")
 parser.add_argument('--system_prompt', type=str, default=DEFAULT_SYSTEM_PROMPT, help="The system prompt of the prompt template.")
+parser.add_argument('--negative_prompt', type=str, default=None, help="Negative prompt in CFG sampling.")
+parser.add_argument('--guidance_scale', type=float, default=1.0, help="The guidance scale for CFG sampling. CFG is enabled by setting `guidance_scale > 1`.")
 args = parser.parse_args()
+
+if args.guidance_scale > 1:
+    try:
+        from transformers.generation import UnbatchedClassifierFreeGuidanceLogitsProcessor
+    except ImportError:
+        raise ImportError("Please install the latest transformers (commit equal or later than d533465) to enable CFG sampling.")
+
 if args.use_vllm:
     if args.lora_model is not None:
         raise ValueError("vLLM currently does not support LoRA, please merge the LoRA weights to the base model.")
@@ -33,6 +42,8 @@ if args.use_vllm:
         raise ValueError("vLLM currently does not support quantization, please use fp16 (default) or unuse --use_vllm.")
     if args.only_cpu:
         raise ValueError("vLLM requires GPUs with compute capability not less than 7.0. If you want to run only on CPU, please unuse --use_vllm.")
+    if args.guidance_scale > 1:
+        raise ValueError("guidance_scale > 1, but vLLM does not support CFG sampling. Please unset guidance_scale. ")
 if args.load_in_8bit and args.load_in_4bit:
     raise ValueError("Only one quantization method can be chosen for inference. Please check your arguments")
 if args.only_cpu is True:
@@ -76,8 +87,7 @@ else:
 
 sample_data = ["为什么要减少污染，保护环境？"]
 
-def generate_prompt(instruction):
-    system_prompt = args.system_prompt or DEFAULT_SYSTEM_PROMPT
+def generate_prompt(instruction, system_prompt = DEFAULT_SYSTEM_PROMPT):
     return TEMPLATE.format_map({'instruction': instruction,'system_prompt': system_prompt})
 
 if __name__ == '__main__':
@@ -156,22 +166,44 @@ if __name__ == '__main__':
                 if len(raw_input_text.strip())==0:
                     break
                 if args.with_prompt:
-                    input_text = generate_prompt(instruction=raw_input_text)
+                    input_text = generate_prompt(instruction=raw_input_text, system_prompt=args.system_prompt)
+                    negative_text = None if args.negative_prompt is None \
+                        else generate_prompt(instruction=raw_input_text, system_prompt=args.negative_prompt)
                 else:
                     input_text = raw_input_text
+                    negative_text = args.negative_prompt
 
                 if args.use_vllm:
                     output = model.generate([input_text], SamplingParams(**generation_config), use_tqdm=False)
                     response = output[0].outputs[0].text
                 else:
                     inputs = tokenizer(input_text,return_tensors="pt")  #add_special_tokens=False ?
-                    generation_output = model.generate(
-                        input_ids = inputs["input_ids"].to(device),
-                        attention_mask = inputs['attention_mask'].to(device),
-                        eos_token_id=tokenizer.eos_token_id,
-                        pad_token_id=tokenizer.pad_token_id,
-                        generation_config = generation_config
-                    )
+                    if args.guidance_scale ==1:
+                        generation_output = model.generate(
+                            input_ids = inputs["input_ids"].to(device),
+                            attention_mask = inputs['attention_mask'].to(device),
+                            eos_token_id=tokenizer.eos_token_id,
+                            pad_token_id=tokenizer.pad_token_id,
+                            generation_config = generation_config
+                        )
+                    else: # enable CFG sampling
+                        if negative_text is None:
+                            negative_prompt_ids = None
+                            negative_prompt_attention_mask = None
+                        else:
+                            negative_inputs = tokenizer(negative_text,return_tensors="pt")
+                            negative_prompt_ids = negative_inputs["input_ids"].to(device)
+                            negative_prompt_attention_mask = negative_inputs["attention_mask"].to(device)
+                        generation_output = model.generate(
+                            input_ids = inputs["input_ids"].to(device),
+                            attention_mask = inputs['attention_mask'].to(device),
+                            eos_token_id=tokenizer.eos_token_id,
+                            pad_token_id=tokenizer.pad_token_id,
+                            generation_config = generation_config,
+                            guidance_scale = args.guidance_scale,
+                            negative_prompt_ids = negative_prompt_ids,
+                            negative_prompt_attention_mask = negative_prompt_attention_mask
+                        )
                     s = generation_output[0]
                     output = tokenizer.decode(s,skip_special_tokens=True)
                     if args.with_prompt:
@@ -185,7 +217,7 @@ if __name__ == '__main__':
             results = []
             if args.use_vllm:
                 if args.with_prompt is True:
-                    inputs = [generate_prompt(example) for example in examples]
+                    inputs = [generate_prompt(example, system_prompt=args.system_prompt) for example in examples]
                 else:
                     inputs = examples
                 outputs = model.generate(inputs, SamplingParams(**generation_config))
@@ -201,18 +233,40 @@ if __name__ == '__main__':
 
             else:
                 for index, example in enumerate(examples):
-                    if args.with_prompt is True:
-                        input_text = generate_prompt(instruction=example)
+                    if args.with_prompt:
+                        input_text = generate_prompt(instruction=example, system_prompt=args.system_prompt)
+                        negative_text = None if args.negative_prompt is None else \
+                            generate_prompt(instruction=example, system_prompt=args.negative_prompt)
                     else:
                         input_text = example
+                        negative_text = args.negative_prompt
                     inputs = tokenizer(input_text,return_tensors="pt")  #add_special_tokens=False ?
-                    generation_output = model.generate(
-                        input_ids = inputs["input_ids"].to(device),
-                        attention_mask = inputs['attention_mask'].to(device),
-                        eos_token_id=tokenizer.eos_token_id,
-                        pad_token_id=tokenizer.pad_token_id,
-                        generation_config = generation_config
-                    )
+                    if args.guidance_scale ==1:
+                        generation_output = model.generate(
+                            input_ids = inputs["input_ids"].to(device),
+                            attention_mask = inputs['attention_mask'].to(device),
+                            eos_token_id=tokenizer.eos_token_id,
+                            pad_token_id=tokenizer.pad_token_id,
+                            generation_config = generation_config
+                        )
+                    else: # enable CFG sampling
+                        if negative_text is None:
+                            negative_prompt_ids = None
+                            negative_prompt_attention_mask = None
+                        else:
+                            negative_inputs = tokenizer(negative_text,return_tensors="pt")
+                            negative_prompt_ids = negative_inputs["input_ids"].to(device)
+                            negative_prompt_attention_mask = negative_inputs["attention_mask"].to(device)
+                        generation_output = model.generate(
+                            input_ids = inputs["input_ids"].to(device),
+                            attention_mask = inputs['attention_mask'].to(device),
+                            eos_token_id=tokenizer.eos_token_id,
+                            pad_token_id=tokenizer.pad_token_id,
+                            generation_config = generation_config,
+                            guidance_scale = args.guidance_scale,
+                            negative_prompt_ids = negative_prompt_ids,
+                            negative_prompt_attention_mask = negative_prompt_attention_mask
+                        )
                     s = generation_output[0]
                     output = tokenizer.decode(s,skip_special_tokens=True)
                     if args.with_prompt:


### PR DESCRIPTION
### Description

1. Add Classifier-Free Guidance (CFG) Sampling to the inference scripts (`inference_hf.py` and `gradio_demo.py`)
2. Fix a problem in `web_demo.py` where the `system_prompt` is not placed into the prompt template.

CFG sampling is a a lightweight technique to encourage prompt-adherence in generations.
* The strength of the CFG sampling is controlled by the parameter `guidance_scale`. CFG sampling is enabled when `guidance_scale > 1`.
* In CFG sampling, users can provide a system prompt and a negative prompt to better guide the generation.

The details of CFG sampling: https://github.com/huggingface/transformers/issues/24536
This PR requires 🤗transformers version later than the commit: https://github.com/huggingface/transformers/pull/24654. 
A version check is included in the PR. CFG sampling is disabled if 🤗transformers does not support it.

### Example

Without CFG:
```
system_prompt: 你是一个乐于助人的助手。请用英文回复下面的指令。
instruction:太阳系中有哪几大行星？
output: 太阳系中共有八大行星，按照距离太阳的远近依次为：水星、金星、地球、火星、木星、土星、天王星、海王星和冥王星（现已被归类为矮行星）。
```


With CFG :
```
system_prompt: 你是一个乐于助人的助手。请用英文回复下面的指令。
negative_prompt: You are a helpful assistant. 你是一个乐于助人的助手。
guidance_scale: 2.0
instruction:太阳系中有哪几大行星？
output: There are eight major planets in the Solar System. There planets are: Mercury, Venus, Earth, Mars, Jupiter, Saturn, Uranus and Neptune.
```
<img width="1419" alt="screen" src="https://github.com/ymcui/Chinese-LLaMA-Alpaca-2/assets/4355449/858bc099-88bb-4e78-aab8-c64d6bcc2d54">

### Related Issue

None.
