### PR TITLE
llama.cpp: remove `-eps` term due to deprecation in new gguf format

### DIFF
--- a/scripts/llama-cpp/chat.sh
+++ b/scripts/llama-cpp/chat.sh
@@ -9,7 +9,7 @@ MODEL_PATH=$1
 FIRST_INSTRUCTION=$2
 
 ./main -m "$MODEL_PATH" \
---color -i -c 4096 -t 8 --temp 0.5 --top_k 40 --top_p 0.9 --repeat_penalty 1.1 -eps 1e-5 \
+--color -i -c 4096 -t 8 --temp 0.5 --top_k 40 --top_p 0.9 --repeat_penalty 1.1 \
 --in-prefix-bos --in-prefix ' [INST] ' --in-suffix ' [/INST]' -p \
 "[INST] <<SYS>>
 $SYSTEM_PROMPT


### PR DESCRIPTION
### Description

[llama.cpp](https://github.com/ggerganov/llama.cpp) has been updated with breaking changes, introducing a new `gguf` format instead of the old one.

The new version deprecates the epsilon term of RMS norm specification via `-eps` option. This will be automatically handled during the conversion of the model. And thus, we are removing `-eps` in our script to make it compatible with new `gguf` models.

**⚠️ WARNING: If you decide to use older version of llama.cpp, please restore `-eps 1e-5` when using Llama-2 based models.**

### Related Issue

None.

### Explanation of Changes

copilot:walkthrough
