### PR TITLE
Update long context patches to support 16K-context models

### DIFF
--- a/scripts/attn_and_long_ctx_patches.py
+++ b/scripts/attn_and_long_ctx_patches.py
@@ -18,6 +18,7 @@ STORE_KV_BEFORE_ROPE = False
 USE_MEM_EFF_ATTENTION = False
 ALPHA = 1.0
 AUTO_COEFF = 1.0
+SCALING_FACTOR = None
 
 
 def apply_rotary_pos_emb_single(q, cos, sin, position_ids):
@@ -124,10 +125,25 @@ def xformers_forward(
 
 old_init = transformers.models.llama.modeling_llama.LlamaRotaryEmbedding.__init__
 
-def adaptive_ntk_init(self, dim, max_position_embeddings=2048, base=10000, device=None):
-    self.dim = dim
+
+def _set_cos_sin_cache(self, seq_len, device, dtype):
+    self.max_seq_len_cached = seq_len
+    t = torch.arange(self.max_seq_len_cached, device=device, dtype=torch.float32)
+    t = t / self.scaling_factor
+
+    freqs = torch.einsum("i,j->ij", t, self.ntk_inv_freq.to(device))
+    # Different from paper, but it uses a different permutation in order to obtain the same calculation
+    emb = torch.cat((freqs, freqs), dim=-1)
+    self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
+    self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
+
+
+def adaptive_ntk_init(self, dim, max_position_embeddings=2048, base=10000, device=None, scaling_factor=None):
     self.alpha = ALPHA
-    self.max_position_embeddings = max_position_embeddings
+    if SCALING_FACTOR is None:
+        self.scaling_factor = scaling_factor or 1.0
+    else:
+        self.scaling_factor = SCALING_FACTOR
     if isinstance(ALPHA,(float,int)):
         base = base * ALPHA ** (dim / (dim-2))
         self.base = base
@@ -136,24 +152,21 @@ def adaptive_ntk_init(self, dim, max_position_embeddings=2048, base=10000, devic
     else:
         raise ValueError(ALPHA)
     old_init(self, dim, max_position_embeddings, base, device)
-    ntk_inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
-    self.register_buffer("ntk_inv_freq", ntk_inv_freq, persistent=False)
+    self.ntk_inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2).float().to(device) / dim))
+
+    self._set_cos_sin_cache = _set_cos_sin_cache
+    self._set_cos_sin_cache(
+        self, seq_len=max_position_embeddings, device=self.ntk_inv_freq.device, dtype=torch.get_default_dtype()
+    )
+
 
 def adaptive_ntk_forward(self, x, seq_len=None):
     if seq_len > self.max_seq_len_cached:
         if isinstance(self.alpha,(float,int)):
-            self.max_seq_len_cached = seq_len
-            t = torch.arange(seq_len, device=x.device, dtype=self.ntk_inv_freq.dtype)
-            freqs = torch.einsum("i,j->ij", t, self.ntk_inv_freq)
-            emb = torch.cat((freqs, freqs), dim=-1).to(x.device)
-            self.register_buffer("cos_cached", emb.cos()[None, None, :, :], persistent=False)
-            self.register_buffer("sin_cached", emb.sin()[None, None, :, :], persistent=False)
-            return (
-                self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
-                self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
-            )
+            self._set_cos_sin_cache(self, seq_len=seq_len, device=x.device, dtype=x.dtype)
         elif self.alpha=='auto':
-            t = torch.arange(seq_len, device=x.device, dtype=self.ntk_inv_freq.dtype)
+            t = torch.arange(seq_len, device=x.device, dtype=torch.float32)
+            t = t / self.scaling_factor
             dim = self.dim
             alpha = (seq_len / (self.max_position_embeddings/2) - 1) * AUTO_COEFF
             base = self.base * alpha ** (dim / (dim-2))
@@ -167,11 +180,10 @@ def adaptive_ntk_forward(self, x, seq_len=None):
                 cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
                 sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype)
             )
-    else:
-        return (
-            self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
-            self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype)
-        )
+    return (
+        self.cos_cached[:, :, :seq_len, ...].to(dtype=x.dtype),
+        self.sin_cached[:, :, :seq_len, ...].to(dtype=x.dtype)
+    )
 
 
 def apply_attention_patch(
@@ -187,15 +199,25 @@ def apply_attention_patch(
     transformers.models.llama.modeling_llama.LlamaAttention.forward = xformers_forward
 
 
-def apply_ntk_scaling_patch(alpha: Union[float,str]):
+def apply_ntk_scaling_patch(alpha: Union[float,str], scaling_factor: Optional[float] = None):
     global ALPHA
+    global SCALING_FACTOR
     ALPHA = alpha
+    SCALING_FACTOR = scaling_factor
     try:
         ALPHA = float(ALPHA)
     except ValueError:
         if ALPHA!="auto":
             raise ValueError(f"Alpha can only be a float or 'auto', but given {ALPHA}")
     print(f"Apply NTK scaling with ALPHA={ALPHA}")
+    if scaling_factor is None:
+        print(f"The value of scaling factor will be read from model config file, or set to 1.")
+    else:
+        print(f"Warning: scaling factor is set to {SCALING_FACTOR}. \
+              If you set the value by hand, do not forget to update \
+              max_position_embeddings in the model config file.")
 
     transformers.models.llama.modeling_llama.LlamaRotaryEmbedding.__init__ = adaptive_ntk_init
+    if hasattr(transformers.models.llama.modeling_llama,'LlamaLinearScalingRotaryEmbedding'):
+        transformers.models.llama.modeling_llama.LlamaLinearScalingRotaryEmbedding.__init__ = adaptive_ntk_init
     transformers.models.llama.modeling_llama.LlamaRotaryEmbedding.forward = adaptive_ntk_forward


### PR DESCRIPTION
### Description

1. The patch script has been updated to support both PI and NTK methods for context extending.
2. The patch script can extend the Chinese-LLaMA-2-16K to longer context length (~ 32K) by applying both PI and adaptive NTK methods.
3. This patch is compatible with transformers 4.31 and it is also recommended to be used together with transformers 4.31.

### Usage
To keep it simple, the usage remains the same as the old one, except that there is an optional argument `scaling_factor`:
```python
from attn_and_long_ctx_patches import apply_ntk_scaling_patch
apply_ntk_scaling_patch(alpha, scaling_factor=None)
```
The value of `scaling_factor` will be set automatically from the model config file, so usually users do not have to specify its value. But I tend to provide this argument for flexibility and easy debugging.