### PR TITLE
fix peft init

### DIFF
--- a/scripts/training/peft/__init__.py
+++ b/scripts/training/peft/__init__.py
@@ -47,7 +47,7 @@ from .utils import (
     TaskType,
     bloom_model_postprocess_past_key_value,
     get_peft_model_state_dict,
-    prepare_model_for_int8_training,
+    # prepare_model_for_int8_training,
     set_peft_model_state_dict,
     shift_tokens_right,
 )

--- a/scripts/training/peft/utils/__init__.py
+++ b/scripts/training/peft/utils/__init__.py
@@ -23,7 +23,7 @@ from .other import (
     TRANSFORMERS_MODELS_TO_PREFIX_TUNING_POSTPROCESS_MAPPING,
     _set_trainable,
     bloom_model_postprocess_past_key_value,
-    prepare_model_for_int8_training,
+    # prepare_model_for_int8_training,
     shift_tokens_right,
     transpose,
 )


### PR DESCRIPTION
### Description

This PR fixes the `prepare_model_for_int8_training` import error in peft initialization. 4/8/16bits training is verified to run correctly.

### Related Issue

#239 

### Explanation of Changes

copilot:walkthrough