### PR TITLE
update requirement of peft

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
+peft>=0.3.0
 torch==2.0.1
-git+https://github.com/huggingface/peft.git@13e53fc
 transformers==4.31.0
 sentencepiece==0.1.97
 bitsandbytes==0.41.0


### PR DESCRIPTION
### Description

Since we have provided a custom peft under `scripts/training/`, we no longer require users to install the specific peft version peft@13e53fc. The training scripts will automatically find and load the custom peft.

However, peft is still needed for running other inference scripts. Thus we recommend using the official peft for inference and using the custom peft only for training.

We have tested with peft==0.3.0 and peft==0.5.0, both of which work with the inference scripts.

### Related Issue

None.

### Explanation of Changes

copilot:walkthrough