### PR TITLE
LangChain: update default hparams

### DIFF
--- a/scripts/langchain/langchain_qa.py
+++ b/scripts/langchain/langchain_qa.py
@@ -73,11 +73,16 @@ if __name__ == '__main__':
     model = HuggingFacePipeline.from_model_id(model_id=model_path,
             task="text-generation",
             device=0,
+            pipeline_kwargs={
+                "max_new_tokens": 400,
+                "do_sample": True,
+                "temperature": 0.2,
+                "top_k": 40,
+                "top_p": 0.9,
+                "repetition_penalty": 1.1},
             model_kwargs={
-                          "torch_dtype" : load_type,
-                          "low_cpu_mem_usage" : True,
-                          "temperature": 0.2,
-                          "repetition_penalty":1.1}
+                "torch_dtype": load_type,
+                "low_cpu_mem_usage": True}
             )
 
     if args.chain_type == "stuff":

--- a/scripts/langchain/langchain_sum.py
+++ b/scripts/langchain/langchain_sum.py
@@ -50,11 +50,16 @@ if __name__ == '__main__':
     model = HuggingFacePipeline.from_model_id(model_id=model_path,
             task="text-generation",
             device=0,
+            pipeline_kwargs={
+                "max_new_tokens": 400,
+                "do_sample": True,
+                "temperature": 0.2,
+                "top_k": 40,
+                "top_p": 0.9,
+                "repetition_penalty": 1.1},
             model_kwargs={
-                          "torch_dtype" : load_type,
-                          "low_cpu_mem_usage" : True,
-                          "temperature": 0.2,
-                          "repetition_penalty":1.1}
+                "torch_dtype" : load_type,
+                "low_cpu_mem_usage" : True}
             )
 
     PROMPT = PromptTemplate(template=prompt_template, input_variables=["text"])


### PR DESCRIPTION
### Description

This PR fixes potential errors in setting the hparams in LangChain examples.

Fixes:
1. `temperature` and `repetition_penalty` should be moved to `pipeline_kwargs` (?)
2. Keep other hparams consistent with `inference_hf.py`, including:
 - `max_new_tokens`: 400
 - `do_sample`: True
 - `top_k`: 40
 - `top_p`: 0.9

Tested under Google Colab.

### Related Issue

None.

### Explanation of Changes

copilot:walkthrough